### PR TITLE
Faz com que funções do env aloquem memória para a chave e o valor

### DIFF
--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/02 11:23:33 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/08/02 12:52:20 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/08/02 18:17:21 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,8 @@ void	export(char **args)
 		key = ft_substr(*args, 0, equal_sign - *args);
 		value = ft_strdup(equal_sign + 1);
 		set_env(key, value);
+		free((void *)key);
+		free((void *)value);
 		args++;
 	}
 }

--- a/src/env/set_env.c
+++ b/src/env/set_env.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/02 10:39:40 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/08/02 16:30:23 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/08/02 18:16:43 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,18 +18,16 @@ static	t_env	*new_env(const char *key, const char *value, t_env *prev)
 	t_env	*env;
 
 	env = ft_calloc(1, sizeof(t_env));
-	env->key = key;
-	env->value = value;
+	env->key = ft_strdup(key);
+	env->value = ft_strdup(value);
 	env->prev = prev;
 	return (env);
 }
 
-static	t_env	*update_env(t_env	*env, const char *key, const char *value)
+static	t_env	*update_env(t_env	*env, const char *value)
 {
-	free((void *)env->key);
 	free((void *)env->value);
-	env->key = key;
-	env->value = value;
+	env->value = ft_strdup(value);
 	return (env);
 }
 
@@ -44,7 +42,7 @@ t_env	*set_env(const char *key, const char*value)
 	}
 	env = get_env(key);
 	if (env != NULL)
-		return (update_env(env, key, value));
+		return (update_env(env, value));
 	env = g_sh.env;
 	while (env->next != NULL)
 		env = env->next;

--- a/src/env/setup_env.c
+++ b/src/env/setup_env.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/02 10:47:03 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/08/02 12:51:41 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/08/02 18:17:01 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,8 @@ void	setup_env(char **envp)
 		key = ft_substr(*envp, 0, equal_sign - *envp);
 		value = ft_strdup(equal_sign + 1);
 		set_env(key, value);
+		free((void *)key);
+		free((void *)value);
 		envp++;
 	}
 }


### PR DESCRIPTION
### Sobre o PR
Agora as funções de env alocam e liberam memória por si só, diminuindo a quantidade de código.